### PR TITLE
Use pytest fixups

### DIFF
--- a/scripts/run-python-tests.sh
+++ b/scripts/run-python-tests.sh
@@ -10,4 +10,4 @@ set -eu
 scriptdir=$(readlink -f "$(dirname "$0")")
 cd "$scriptdir/.."
 
-pytest -svx source/Mlos.Python
+pytest -svxl source/Mlos.Python $*

--- a/source/Mlos.Python/mlos/Grpc/OptimizerMicroserviceServer.py
+++ b/source/Mlos.Python/mlos/Grpc/OptimizerMicroserviceServer.py
@@ -42,10 +42,11 @@ class OptimizerMicroserviceServer:
         self.logger.info("OptimizerMicroserviceServer started")
 
     def stop(self, grace=None):
-        self._server.stop(grace=grace)
-        self.logger.info("OptimizerMicroserviceServer stopped")
-
+        stop_event = self._server.stop(grace=grace)
+        self.logger.info("OptimizerMicroserviceServer stop requested")
+        return stop_event
 
     def wait_for_termination(self, timeout=None):
-        if self.started:
-            self._server.wait_for_termination(timeout=timeout)
+        if self._server:
+            return self._server.wait_for_termination(timeout=timeout)
+        return True

--- a/source/Mlos.Python/mlos/unit_tests/TestBayesianOptimizerGrpcClient.py
+++ b/source/Mlos.Python/mlos/unit_tests/TestBayesianOptimizerGrpcClient.py
@@ -54,11 +54,14 @@ class TestBayesianOptimizerGrpcClient(unittest.TestCase):
         )
 
     def tearDown(self):
-        """ We need to tear down the gRPC server here.
+        """ We need to tear down the gRPC server and client here.
 
         :return:
         """
-        self.server.stop(grace=None)
+        self.server.stop(grace=None).wait(timeout=1)
+        self.server.wait_for_termination(timeout=1)
+        self.optimizer_service_channel.close()
+
 
     def test_echo(self):
         optimizer_service_stub = OptimizerServiceStub(channel=self.optimizer_service_channel)


### PR DESCRIPTION
Here are some fixups that appear to address the current failures in https://github.com/microsoft/MLOS/pull/154.

Basically, we make sure to wait on the grpc server tear-down and also cleanup the client connection.

One issue I'm still seeing is that in the following output, you'll notice that the `OptimizerMicroserviceServer.py:  42 -                     start()` output is repeated a second time for the second test.  It seems that something is still lingering ...

Repro instructions:

```sh
make docker-image
docker run -it -v $PWD:/src/MLOS --name mlos-build-test --rm mlos-build-ubuntu-20.04
./scripts/run-python-tests.sh -k TestBayesianOptimizerGrpcClient
```

```txt
mlos-docker@0e8a90dde10d:/src/MLOS$ scripts/run-python-tests.sh -k TestBayesianOptimizerGrpcClient 2>&1 | tee /tmp/out
============================= test session starts ==============================
platform linux -- Python 3.7.9, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3.7
cachedir: .pytest_cache
rootdir: /src/MLOS, configfile: pytest.ini
collecting ... collected 122 items / 118 deselected / 4 selected

source/Mlos.Python/mlos/unit_tests/TestBayesianOptimizerGrpcClient.py::TestBayesianOptimizerGrpcClient::test_echo 11/04/2020 23:54:19 -      OptimizerMicroservice -    INFO - [OptimizerMicroservice.py:  40 -                  __init__() ] OptimizerMicroservice init
11/04/2020 23:54:19 - OptimizerMicroserviceServer init -    INFO - [OptimizerMicroserviceServer.py:  42 -                     start() ] OptimizerMicroserviceServer started
11/04/2020 23:54:19 - OptimizerMicroserviceServer init -    INFO - [OptimizerMicroserviceServer.py:  46 -                      stop() ] OptimizerMicroserviceServer stop requested
PASSED
source/Mlos.Python/mlos/unit_tests/TestBayesianOptimizerGrpcClient.py::TestBayesianOptimizerGrpcClient::test_optimizer_with_default_config 11/04/2020 23:54:19 -      OptimizerMicroservice -    INFO - [OptimizerMicroservice.py:  40 -                  __init__() ] OptimizerMicroservice init
11/04/2020 23:54:19 -      OptimizerMicroservice -    INFO - [OptimizerMicroservice.py:  40 -                  __init__() ] OptimizerMicroservice init
11/04/2020 23:54:19 - OptimizerMicroserviceServer init -    INFO - [OptimizerMicroserviceServer.py:  42 -                     start() ] OptimizerMicroserviceServer started
11/04/2020 23:54:19 - OptimizerMicroserviceServer init -    INFO - [OptimizerMicroserviceServer.py:  42 -                     start() ] OptimizerMicroserviceServer started
```